### PR TITLE
Simplify logic for objectsEqual() utility

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -117,24 +117,15 @@ const processStack = () => Object.keys(stack).forEach(process);
  * @return {boolean}
  */
 const objectsEqual = (objA, objB) => {
-	const objAKeys = Object.keys(objA).sort();
-	const objBKeys = Object.keys(objB).sort();
+	const objAKeys = Object.keys(objA);
+	const objBKeys = Object.keys(objB);
 
-	if (objAKeys.length !== objBKeys.length) {
-		return false;
-	}
+	const valueIsEqual = key => objB.hasOwnProperty(key) && objA[key] === objB[key];
 
-	for (let i = 0; i < objAKeys.length; i++) {
-		if (objAKeys[i] !== objBKeys[i]) {
-			return false;
-		}
-		const key = objAKeys[i];
-
-		if (objA[key] !== objB[key]) {
-			return false;
-		}
-	}
-	return true;
+	return (
+		objAKeys.length === objBKeys.length
+		&& objectAKeys.every(valueIsEqual)
+	);
 };
 
 if (!isNode) {


### PR DESCRIPTION
Small PR to simplify logic for `objectsEqual()` utility.

We don't have to sort our keys as we did in the original implementation. Instead, we can check shallow equality using three conditions:

1. number of keys in A and B are equal
2. Every property in A exists in B
3. Every key/value pair of A exists in B