### PR TITLE
Split logic for useLink and A component

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A hook based router for React",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest unittest/",
     "prepublishOnly": "babel ./src --out-dir ./dist -s inline",
     "preTest": "npm run prepublishOnly && babel ./test/src --out-dir ./test/dist -s inline && npm run webpack",
     "webpack": "webpack ./test/dist/index.js -o ./test/dist/pack.js --devtool source-map",
@@ -32,9 +32,11 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "http-server": "0.11.1",
+    "jest": "24.6.0",
     "node": "11.12.0",
     "react": "16.8.2",
     "react-dom": "16.8.5",
+    "react-test-renderer": "16.8.5",
     "webpack": "4.29.6",
     "webpack-cli": "3.3.0"
   }

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,27 +1,50 @@
 import React from "react";
 import {navigate, getBasepath} from "./router";
 
-const A = (props) => {
-	const {onClick: originalOnClick} = props;
-	const basePath = getBasepath();
+/**
+ * Accepts HTML `a`-tag properties, requiring `href` and optionally
+ * `onClick`, which are appropriately wrapped to allow other
+ * frameworks to be used for creating `hookrouter` navigatable links.
+ *
+ * If `onClick` is supplied, then the navigation will happen before
+ * the supplied `onClick` action!
+ *
+ * @example
+ *
+ * &lt;MyFrameworkLink what="ever" {...useLink({ href: '/' })}&gt;
+ *   Link text
+ * &lt;/MyFrameworkLink&gt;
+ *
+ * @param {Object} props Requires `href`. `onClick` is optional.
+ */
+export const useLink = (props) => {
+  const onClick = (e) => {
+    e.preventDefault(); // prevent the link from actually navigating
 
-	const onClick = (e) => {
-		e.preventDefault();
+    navigate(e.currentTarget.href);
 
-		navigate(e.currentTarget.href);
+    if (props.onClick) {
+      props.onClick(e);
+    }
+  };
+  const href =
+    props.href.substr(0, 1) === '/'
+      ? getBasepath() + props.href
+      : props.href;
 
-		if (originalOnClick) {
-			originalOnClick(e);
-		}
-	};
-
-	const href = props.href.substr(0, 1) === '/'
-		? basePath + props.href
-		: props.href;
-
-	return (
-		<a {...props} href={href} onClick={onClick}/>
-	);
+  return {href, onClick};
 };
 
-export default A;
+/**
+ * Accepts standard HTML `a`-tag properties. `href` and, optionally,
+ * `onClick` are used to create links that work with `hookrouter`.
+ *
+ * @example
+ *
+ * &lt;A href="/" target="_blank"&gt;
+ *   Home
+ * &lt;/A&gt;
+ *
+ * @param {Object} props Requires `href`. `onClick` is optional
+ */
+export const A = (props) => <a {...props} {...useLink(props)}/>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import A from './Link';
+import {A, useLink} from './Link';
 import useRedirect from './redirect';
 import {useQueryParams, setQueryParams, getQueryParams} from "./queryParams";
 import {useInterceptor} from './interceptor';
@@ -15,6 +15,7 @@ import {
 
 export {
 	A,
+	useLink,
 	useRedirect,
 	useTitle,
 	useQueryParams,

--- a/test/src/App.js
+++ b/test/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useRoutes, useTitle, useRedirect, useQueryParams, useInterceptor, A} from '../../dist';
+import {useRoutes, useTitle, useRedirect, useQueryParams, useInterceptor, A, useLink} from '../../dist';
 
 const products = {
 	"1": "Rainbow Fish",
@@ -74,8 +74,12 @@ const Products = () => {
 								? -1
 								: 1
 					)
-					.map(([id, title]) => <li key={id}><A href={`/product/${id}`}>{title}</A>
-					</li>)}
+					// Note: the link uses the useLink method, but you should prefer using
+					// the hookrouter 'A' component if you are not using a framework that
+					// requires href / onClick to be provided to it
+					.map(([id, title]) => (
+						<li key={id}><a {...useLink({ href: `/product/${id}` })}>{title}</a></li>
+					))}
 			</ul>
 		</React.Fragment>
 	);

--- a/unittest/Link.test.js
+++ b/unittest/Link.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {navigate, getBasepath} from "../src/router";
+import {A, useLink} from "../src";
+
+// allow us to mock navigate and getBasepath
+jest.mock("../src/router");
+
+describe('Link.js', () => {
+
+  describe('useLink', () => {
+
+    test('throws error when href not supplied', () => {
+      expect(() => useLink()).toThrow();
+      expect(() => useLink({onClick: () => null})).toThrow();
+    });
+
+    test('provides onClick that performs navigation', () => {
+      const {href, onClick} = useLink({href: "test1"});
+
+      expect(href).toBe("test1");
+      expect(onClick).toBeInstanceOf(Function);
+
+      const e = {
+        preventDefault: jest.fn(),
+        currentTarget: {
+          href: "onClick1"
+        }
+      };
+
+      onClick(e);
+
+      expect(e.preventDefault).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith("onClick1");
+    });
+
+    test('wraps onClick and triggers wrapped onClick with event', () => {
+      const wrappedOnClick = jest.fn();
+      const {href, onClick} = useLink({href: "test2", onClick: wrappedOnClick});
+
+      expect(href).toBe("test2");
+      expect(onClick).toBeInstanceOf(Function);
+
+      const e = {
+        preventDefault: jest.fn(),
+        currentTarget: {
+          href: "onClick2"
+        }
+      };
+
+      onClick(e);
+
+      expect(e.preventDefault).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith("onClick2");
+      expect(wrappedOnClick).toHaveBeenCalledWith(e);
+    });
+
+    test('uses getBasepath() when href starts with /', () => {
+      getBasepath.mockReturnValue("/test3");
+
+      const {href, onClick} = useLink({href: "/test-basepath"});
+
+      expect(href).toBe("/test3/test-basepath");
+      expect(onClick).toBeInstanceOf(Function);
+    });
+
+  });
+
+  describe('A', () => {
+
+    test('renders correctly with href', () => {
+      getBasepath.mockReturnValue("");
+
+      const tree = renderer
+        .create(<A href="/Paratron/hookrouter">hookrouter</A>)
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    test('renders correctly with href and onClick', () => {
+      getBasepath.mockReturnValue("");
+
+      const tree = renderer
+        .create(<A href="/Paratron/hookrouter" onClick={() => null}>hookrouter</A>)
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    test('renders correctly with href, onClick, and target', () => {
+      getBasepath.mockReturnValue("");
+
+      const tree = renderer
+        .create(<A href="/Paratron/hookrouter" onClick={() => null} target="_blank">hookrouter</A>)
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    test('renders correctly with href, onClick, and target plus basepath', () => {
+      getBasepath.mockReturnValue("/test4");
+
+      const tree = renderer
+        .create(<A href="/Paratron/hookrouter" onClick={() => null} target="_blank">hookrouter</A>)
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+  });
+
+});

--- a/unittest/__snapshots__/Link.test.js.snap
+++ b/unittest/__snapshots__/Link.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Link.js A renders correctly with href 1`] = `
+<a
+  href="/Paratron/hookrouter"
+  onClick={[Function]}
+>
+  hookrouter
+</a>
+`;
+
+exports[`Link.js A renders correctly with href and onClick 1`] = `
+<a
+  href="/Paratron/hookrouter"
+  onClick={[Function]}
+>
+  hookrouter
+</a>
+`;
+
+exports[`Link.js A renders correctly with href, onClick, and target 1`] = `
+<a
+  href="/Paratron/hookrouter"
+  onClick={[Function]}
+  target="_blank"
+>
+  hookrouter
+</a>
+`;
+
+exports[`Link.js A renders correctly with href, onClick, and target plus basepath 1`] = `
+<a
+  href="/test4/Paratron/hookrouter"
+  onClick={[Function]}
+  target="_blank"
+>
+  hookrouter
+</a>
+`;


### PR DESCRIPTION
This adds support for other frameworks to reuse the navigation
logic that comes from hookrouter's `A` stateless component.

I took @FredyC's recommendation for the name `useLink`.

It also adds some unit tests to test the behavior that is
implemented here in addition to the test app.

Closes #24