### PR TITLE
fix useQueryParams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hookrouter",
-  "version": "1.1.4",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/queryParams.js
+++ b/src/queryParams.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import isNode from './isNode';
 
-const queryParamListeners = [];
+const queryParamListeners = new Set();
 let queryParamObject = {};
 
 export const setQueryParams = (inObj, replace = false) => {
@@ -31,7 +31,7 @@ export const getQueryParams = () => Object.assign({}, queryParamObject);
  * @param {string} inStr
  * @return {object}
  */
-const queryStringToObject = (inStr) => {
+export const queryStringToObject = (inStr) => {
 	const p = new URLSearchParams(inStr);
 	let result = {};
 	for (let param of p) {
@@ -68,15 +68,8 @@ export const useQueryParams = () => {
 	const setUpdate = React.useState(0)[1];
 
 	React.useEffect(() => {
-		queryParamListeners.push(setUpdate);
-
-		return () => {
-			const index = queryParamListeners.indexOf(setUpdate);
-			if (index === -1) {
-				return;
-			}
-			queryParamListeners.splice(index, 1);
-		};
+		queryParamListeners.add(setUpdate);
+		return () => queryParamListeners.delete(setUpdate);
 	}, [setUpdate]);
 
 	return [queryParamObject, setQueryParams];

--- a/src/router.js
+++ b/src/router.js
@@ -35,7 +35,7 @@ const resolvePath = (inPath) => {
 
 	const current = new URL(currentPath, location.href);
 	const resolved = new URL(inPath, current);
-	return resolved.pathname;
+	return resolved.toString();
 };
 
 export const ParentContext = React.createContext(null);

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import isNode from './isNode';
-import {setQueryParams} from './queryParams';
+import {setQueryParams, queryStringToObject} from './queryParams';
 import {interceptRoute} from './interceptor';
 
 let preparedRoutes = {};
@@ -35,7 +35,7 @@ const resolvePath = (inPath) => {
 
 	const current = new URL(currentPath, location.href);
 	const resolved = new URL(inPath, current);
-	return resolved.toString();
+	return resolved;
 };
 
 export const ParentContext = React.createContext(null);
@@ -101,10 +101,24 @@ export const navigate = (url, replace = false, queryParams = null, replaceQueryP
 	processStack();
 	updatePathHooks();
 
+	if (!queryParams) {
+		url = new URL(url)
+		queryParams = url.search && entriesToObject(url.searchParams.entries())
+	}
+
 	if (queryParams) {
 		setQueryParams(queryParams, replaceQueryParams);
 	}
 };
+
+function entriesToObject(entries) {
+  let result = {}
+  for(let entry of entries) { // each 'entry' is a [key, value] tupple
+    const [key, value] = entry;
+    result[key] = value;
+  }
+  return result;
+}
 
 let customPath = '/';
 /**


### PR DESCRIPTION
This is for #70. I tested that it works with a local project, npm linking in hookrouter. However, I am unable to run the unittests, they immediately throw a babel error.

This also fixes the problem where using `navigate` or `<A>` with query params wouldn't update `useQueryParams`. 

[From an earlier comment](https://github.com/Paratron/hookrouter/issues/43#issuecomment-487227097)
> Also note that if you do a navigation with query parameters already encoded into the URI, useQueryParams hooks _won't be updated_!

