### PR TITLE
Don't handle click when (Mac) command modifier is pressed

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -19,7 +19,7 @@ import {navigate, getBasepath} from "./router";
  */
 export const setLinkProps = (props) => {
 	const onClick = (e) => {
-		if (!e.shiftKey && !e.ctrlKey && !e.altKey) {
+		if (!e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
 			e.preventDefault(); // prevent the link from actually navigating
 			navigate(e.currentTarget.href);
 		}


### PR DESCRIPTION
The Mac `⌘ Command` modifier was not included in the list of modifiers when filtering the `onClick` events.  Apparently, this is called `metaKey` in the Web API (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey).