### PR TITLE
Fix opening link in new tab on MacOS

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -19,7 +19,7 @@ import {navigate, getBasepath} from "./router";
  */
 export const setLinkProps = (props) => {
 	const onClick = (e) => {
-		if (!e.shiftKey && !e.ctrlKey && !e.altKey) {
+		if (!e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
 			e.preventDefault(); // prevent the link from actually navigating
 			navigate(e.currentTarget.href);
 		}


### PR DESCRIPTION
[Commit 336680e](https://github.com/Paratron/hookrouter/commit/336680e4b29036e24909ec60c48b8ae826f51be3) fixed the issue of modifier keys being ignored when clicking on an `<A>` link, but missed the meta key, which is how link are opened in a new tab on MacOS. Luckily [this key is also provided on the event](https://w3c.github.io/uievents/#dom-mouseevent-metakey). This PR adds this case. I could not find a relevant test to update.