### PR TITLE
Making the base path case insensitive to avoid page not found issues …

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -18,7 +18,7 @@ const pathUpdaters = [];
  */
 export const setBasepath = (inBasepath) => {
 	basePath = inBasepath;
-	basePathRegEx = new RegExp('^' + basePath);
+	basePathRegEx = new RegExp('^' + basePath, 'i');
 };
 
 /**


### PR DESCRIPTION
…with virtual directory
Would it be ok for you if we make the base path case insensitive?
Unfortunately we currently have to dealt with IIS application directories, and users tend to input URLs in any fashion. 
If you see a general problem, maybe we can make this configurable?