### PR TITLE
Fix target=_blank bug

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -19,7 +19,7 @@ import {navigate, getBasepath} from "./router";
  */
 export const setLinkProps = (props) => {
 	const onClick = (e) => {
-		if (!e.shiftKey && !e.ctrlKey && !e.altKey) {
+		if (!e.shiftKey && !e.ctrlKey && !e.altKey && props.target !== "_blank")) {
 			e.preventDefault(); // prevent the link from actually navigating
 			navigate(e.currentTarget.href);
 		}


### PR DESCRIPTION
**Expected**
`target=_blank` attribute opens the linked document in a new window or tab

**Actual**
`target=_blank` doesn't change the behavior of the link.