### PR TITLE
Fix syntax error on line 22 of Link.js

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -19,7 +19,7 @@ import {navigate, getBasepath} from "./router";
  */
 export const setLinkProps = (props) => {
 	const onClick = (e) => {
-		if (!e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && props.target !== "_blank")) {
+		if (!e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && props.target !== "_blank") {
 			e.preventDefault(); // prevent the link from actually navigating
 			navigate(e.currentTarget.href);
 		}


### PR DESCRIPTION
A previous commit (linked to #146) inserted an extra ')' to close the if statement, leading to a syntax error.  This very simple commit fixes it.