### PR TITLE
Preserve hash when changing the query params

### DIFF
--- a/src/queryParams.js
+++ b/src/queryParams.js
@@ -20,7 +20,7 @@ export const setQueryParams = (inObj, replace = false) => {
 		if(qs === location.search) {
 			return;
 		}
-		history.replaceState(null, null, location.pathname + (qs !== '?' ? qs : ''));
+		history.replaceState(null, null, location.pathname + (qs !== '?' ? qs : '') + location.hash);
 	}
 };
 


### PR DESCRIPTION
Currently when you call setQueryParams it clears the current url hash. This is the intended behaviour for history.replaceState as you are most likely changing the pathName. However in the case of setQueryParams, we aren't changing the url location, just the query params. As such, theres no reason the hash should reasonably be wiped.

Here is a change that would preserve not just the pathname on query change, but the hash too.

If hash isnt set, then location.hash is an empty string and causes no issues