### PR TITLE
Fix the `wth` Exception

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -239,6 +239,10 @@ const process = (stackObj, directCall) => {
 		reducedPath: previousReducedPath
 	} = stackObj;
 
+	if (!stack[routerId]) {
+		return;
+	}
+
 	const currentPath = getWorkingPath(parentRouterId);
 	let route = null;
 	let targetFunction = null;
@@ -268,10 +272,6 @@ const process = (stackObj, directCall) => {
 		reducedPath = currentPath.replace(result[0], '');
 		anyMatched = true;
 		break;
-	}
-
-	if (!stack[routerId]) {
-		return;
 	}
 
 	if (!anyMatched) {

--- a/src/router.js
+++ b/src/router.js
@@ -172,6 +172,7 @@ export const getWorkingPath = (parentRouterId) => {
 	}
 	const stackEntry = stack[parentRouterId];
 	if (!stackEntry) {
+    // this should not be reached at all
 		throw 'wth';
 	}
 

--- a/src/router.js
+++ b/src/router.js
@@ -172,7 +172,7 @@ export const getWorkingPath = (parentRouterId) => {
 	}
 	const stackEntry = stack[parentRouterId];
 	if (!stackEntry) {
-    // this should not be reached at all
+		// this should not be reached at all
 		throw 'wth';
 	}
 


### PR DESCRIPTION
This PR fixes #109 and #51.

The issue is caused by the `stack` being modified while it's been processed.

The fix is to simply ignore stack entries that are no longer existing.